### PR TITLE
Add capability to findHref when the anchor contains an image instead of text

### DIFF
--- a/content.js
+++ b/content.js
@@ -29,6 +29,18 @@
       {
         return anchor.href;
       }
+      // If we didn't get anything above, try looking in the firstChildElement?
+      // Some webcomics use images for these links instead of text.
+      if (anchor.firstElementChild !== void 0 &&
+          anchor.firstElementChild !== null)
+      {
+        if (isNameInAnchor(name, anchor.firstElementChild.alt) ||
+            isNameInAnchor(name, anchor.firstElementChild.id) ||
+            isNameInAnchor(name, anchor.firstElementChild.src))
+        {
+          return anchor.href;
+        }
+      }
     }
   }
 

--- a/content.js
+++ b/content.js
@@ -34,12 +34,26 @@
       if (anchor.firstElementChild !== void 0 &&
           anchor.firstElementChild !== null)
       {
-        if (isNameInAnchor(name, anchor.firstElementChild.alt) ||
-            isNameInAnchor(name, anchor.firstElementChild.id) ||
+        // Check the firstElementChild's id and src attributes.
+        if (isNameInAnchor(name, anchor.firstElementChild.id) ||
             isNameInAnchor(name, anchor.firstElementChild.src))
         {
           return anchor.href;
         }
+
+        // findHref stops at first match.
+        // On prev and first (line 7 and line 11), I have observed bad matches when searching alt attributes.
+        // The alt attribute may contain things like "Go way back to the first strip!"
+        // which will get picked up by the search for a "prev" link.
+        // Should find a way around this. Disabling for now.
+        // The "first" object is often before the "prev" object in the document, but not sure if this can be useful here.
+        // Might have to leave out alt in an initial search and try to search again if we get no results on the first pass?
+
+        // Check the firstElementChild's alt attribute last.
+        /*if (isNameInAnchor(name, anchor.firstElementChild.alt))
+        {
+          return anchor.href;
+        }*/
       }
     }
   }


### PR DESCRIPTION
The title here and the commit message more or less explain it.  I added some logic to try to find navigation items in the form of an image (img tag) within a child element of an anchor.  This is because some webcomics use images for their navigation links instead of text.  I added this code after the first return in findHref to try to make the first cases preferred over these cases.
